### PR TITLE
"language" hotfix

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -44,7 +44,7 @@ export default class ProductFruits extends Component {
 
     window.productFruits = window.productFruits || {};
 
-    const fireLanguageChangedEvent = window.productFruits.language && window.productFruits.language !== language;
+    const fireLanguageChangedEvent = window.productFruits && window.productFruits.language && window.productFruits.language !== language;
 
     window.productFruits.language = language;
     window.productFruits.code = projectCode;


### PR DESCRIPTION
Narazili jsme na bug v aplikaci, pokud product-fruit zapínáme pouze na některých stránkách. 

Volá se pak teda `componentWillUnmount` a asi to není vše stopro tam. Padá to pak na erroru:
```
Cannot read property 'language' of undefined
```

Tento hotfix by to měl opravit. Nevím teda zda pak nebude ještě jiný problém ale snad ne.