### PR TITLE
Accept boolean user props

### DIFF
--- a/src/types/PFCore.ts
+++ b/src/types/PFCore.ts
@@ -43,9 +43,9 @@ export type ProductFruitsUserObject = {
 }
 
 export type UserCustomProps = {
-    [key: string]: string | number | Array<string> | Array<number> | UserCustomProps;
+    [key: string]: string | number | boolean | Array<string> | Array<number> | UserCustomProps;
 }
 
 export type UserGroupCustomProps = {
-    [key: string]: string | number | Array<string> | Array<number> | UserCustomProps;
+    [key: string]: string | number | boolean | Array<string> | Array<number> | UserCustomProps;
 }


### PR DESCRIPTION
The documentation (https://help.productfruits.com/en/article/identifying-users#custom-properties) says:

> You can pass custom user information to the `props` field. This object can hold any property with one of these types:
> 
> - string
> - number
> - array of strings or numbers
> - boolean

but the TypeScript doesn't allow us to passt `boolean`s.